### PR TITLE
Add support to listen for check_run webhooks

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/vapor/console.git",
         "state": {
           "branch": null,
-          "revision": "5b9796d39f201b3dd06800437abd9d774a455e57",
-          "version": "3.0.2"
+          "revision": "74cfbea629d4aac34a97cead2447a6870af1950b",
+          "version": "3.1.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/vapor/core.git",
         "state": {
           "branch": null,
-          "revision": "7f56a09995bf3c8df562be456bdcda405d9d0678",
-          "version": "3.4.1"
+          "revision": "2731f8ba0cf274a61c9bd6ab43550f692ffaf879",
+          "version": "3.9.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/vapor/crypto.git",
         "state": {
           "branch": null,
-          "revision": "4b85405430df1892ee3aa1554bdb477e96cf46ad",
-          "version": "3.2.0"
+          "revision": "df8eb7d8ae51787b3a0628aa3975e67666da936c",
+          "version": "3.3.3"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/vapor/database-kit.git",
         "state": {
           "branch": null,
-          "revision": "7a01659316b9f033fa2150d5cd5e9d3c3e46c2e3",
-          "version": "1.3.0"
+          "revision": "8f352c8e66dab301ab9bfef912a01ce1361ba1e4",
+          "version": "1.3.3"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/vapor/http.git",
         "state": {
           "branch": null,
-          "revision": "8123ea00e9858b369cd168d0303d33e7d3804d19",
-          "version": "3.0.7"
+          "revision": "254a0a0cbf22a02b697a075a0d2ddbb448bb7c87",
+          "version": "3.2.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/vapor/multipart.git",
         "state": {
           "branch": null,
-          "revision": "e57007c23a52b68e44ebdfc70cbe882a7c4f1ec3",
-          "version": "3.0.2"
+          "revision": "f919a01c4d10a281d6236a21b0b1d1759a72b8eb",
+          "version": "3.0.4"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/vapor/routing.git",
         "state": {
           "branch": null,
-          "revision": "3219e328491b0853b8554c5a694add344d2c6cfb",
-          "version": "3.0.1"
+          "revision": "626190ddd2bd9f967743b60ba6adaf90bbd2651c",
+          "version": "3.0.2"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/vapor/service.git",
         "state": {
           "branch": null,
-          "revision": "281a70b69783891900be31a9e70051b6fe19e146",
-          "version": "1.0.0"
+          "revision": "fa5b5de62bd68bcde9a69933f31319e46c7275fb",
+          "version": "1.0.2"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "c6acf77fc9a310c0ebf8d5f73f285d1639801d2f",
-          "version": "1.9.0"
+          "revision": "ba7970fe396e8198b84c6c1b44b38a1d4e2eb6bd",
+          "version": "1.14.1"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "6617eb0d3afcb12170594968df01ca63afb58ac5",
-          "version": "1.2.0"
+          "revision": "0f3999f3e3c359cc74480c292644c3419e44a12f",
+          "version": "1.4.0"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/vapor/template-kit.git",
         "state": {
           "branch": null,
-          "revision": "43b57b5861d5181b906ac6411d28645e980bb638",
-          "version": "1.0.1"
+          "revision": "121ae51433df94cf6e15c09e1f1b0f7c77ff8d5c",
+          "version": "1.2.0"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/vapor/url-encoded-form.git",
         "state": {
           "branch": null,
-          "revision": "cbfe7ef6301557d3f2d0807a98165232ae06e1c6",
-          "version": "1.0.4"
+          "revision": "82d8d63bdb76b6dd8febe916c639ab8608dbbaed",
+          "version": "1.0.6"
         }
       },
       {
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/vapor/validation.git",
         "state": {
           "branch": null,
-          "revision": "ab6c5a352d97c8687b91ed4963aef8e7cfe0795b",
-          "version": "2.0.0"
+          "revision": "4de213cf319b694e4ce19e5339592601d4dd3ff6",
+          "version": "2.1.1"
         }
       },
       {
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "54632a6c1e7ecd9923c0d00b612de936de1c4745",
-          "version": "3.0.8"
+          "revision": "c86ada59b31c69f08a6abd4f776537cba48d5df6",
+          "version": "3.3.0"
         }
       },
       {
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/vapor/websocket.git",
         "state": {
           "branch": null,
-          "revision": "141cb4d3814dc8062cb0b2f43e72801b5dfcf272",
-          "version": "1.0.1"
+          "revision": "d85e5b6dce4d04065865f77385fc3324f98178f6",
+          "version": "1.1.2"
         }
       }
     ]

--- a/Sources/Swoctokit/JSONDecoder+Static.swift
+++ b/Sources/Swoctokit/JSONDecoder+Static.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swoctokit open source project
+//
+// Copyright (c) 2018 e-Sixt
+// Licensed under MIT
+//
+// See LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension JSONDecoder {
+    static let convertFromSnakeCase: JSONDecoder = {
+        let decoder = JSONDecoder()
+        if #available(OSX 10.12, *) {
+            decoder.dateDecodingStrategy = .iso8601
+        }
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
+}

--- a/Sources/Swoctokit/Models/Branch.swift
+++ b/Sources/Swoctokit/Models/Branch.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swoctokit open source project
+//
+// Copyright (c) 2018 e-Sixt
+// Licensed under MIT
+//
+// See LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+public struct Branch: Decodable {
+
+    public let name: String
+    public let commit: Commit
+    public let protected: Bool
+    public let protection: Protection?
+
+}
+
+extension Branch {
+    public struct Commit: Decodable {
+        public let sha: String
+    }
+
+    public struct Protection: Decodable {
+        public let enabled: Bool
+        public let requiredStatusChecks: RequiredStatusChecks
+    }
+}
+
+extension Branch.Protection {
+    public struct RequiredStatusChecks: Decodable {
+        public let enforcementLevel: String
+        public let contexts: [String]
+    }
+}

--- a/Sources/Swoctokit/Models/CheckRun.swift
+++ b/Sources/Swoctokit/Models/CheckRun.swift
@@ -11,9 +11,14 @@
 
 import Foundation
 
-public enum EventType: String {
-    case pullRequest = "pull_request"
-    case commitComment = "commit_comment"
-    case issueComment = "issue_comment"
-    case checkRun = "check_run"
+public struct CheckRun: Decodable {
+
+    public let id: Int
+    public let name: String
+    public let headSha: String
+    public let status: String
+    public let conclusion: String?
+    public let completedAt: Date?
+    public let pullRequests: [PullRequest]
+
 }

--- a/Sources/Swoctokit/Models/Comment.swift
+++ b/Sources/Swoctokit/Models/Comment.swift
@@ -1,9 +1,13 @@
+//===----------------------------------------------------------------------===//
 //
-//  Comment.swift
-//  Swoctokit
+// This source file is part of the Swoctokit open source project
 //
-//  Created by Franz Busch on 14.11.18.
+// Copyright (c) 2018 e-Sixt
+// Licensed under MIT
 //
+// See LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
 
 import Foundation
 

--- a/Sources/Swoctokit/Models/Owner.swift
+++ b/Sources/Swoctokit/Models/Owner.swift
@@ -14,10 +14,4 @@ public struct Owner: Decodable {
     public let id: Int
     public let nodeId: String
 
-    private enum CodingKeys: String, CodingKey {
-        case login
-        case id
-        case nodeId = "node_id"
-    }
-
 }

--- a/Sources/Swoctokit/Models/Owner.swift
+++ b/Sources/Swoctokit/Models/Owner.swift
@@ -1,9 +1,13 @@
+//===----------------------------------------------------------------------===//
 //
-//  Owner.swift
-//  Swoctokit
+// This source file is part of the Swoctokit open source project
 //
-//  Created by Franz Busch on 14.11.18.
+// Copyright (c) 2018 e-Sixt
+// Licensed under MIT
 //
+// See LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
 
 import Foundation
 

--- a/Sources/Swoctokit/Models/PullRequest.swift
+++ b/Sources/Swoctokit/Models/PullRequest.swift
@@ -1,9 +1,13 @@
+//===----------------------------------------------------------------------===//
 //
-//  PullRequest.swift
-//  Swoctokit
+// This source file is part of the Swoctokit open source project
 //
-//  Created by Franz Busch on 14.11.18.
+// Copyright (c) 2018 e-Sixt
+// Licensed under MIT
 //
+// See LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
 
 import Foundation
 

--- a/Sources/Swoctokit/Models/PullRequest.swift
+++ b/Sources/Swoctokit/Models/PullRequest.swift
@@ -13,19 +13,25 @@ import Foundation
 
 public struct PullRequest: Decodable {
 
-    public struct Head: Decodable {
-
-        public let label: String
+    public struct Branch: Decodable {
+        public let label: String?
         public let ref: String
         public let sha: String
         public let repo: Repository
     }
 
+    public struct Label: Decodable {
+        public let name: String
+        public let color: String
+    }
+
     public let id: Int
     public let number: Int
-    public let state: String
-    public let title: String
-    public let body: String
-    public let head: Head
+    public let state: String?
+    public let title: String?
+    public let body: String?
+    public let head: Branch
+    public let base: Branch
+    public let labels: [Label]?
 
 }

--- a/Sources/Swoctokit/Models/Repository.swift
+++ b/Sources/Swoctokit/Models/Repository.swift
@@ -1,9 +1,13 @@
+//===----------------------------------------------------------------------===//
 //
-//  Repository.swift
-//  Swoctokit
+// This source file is part of the Swoctokit open source project
 //
-//  Created by Franz Busch on 14.11.18.
+// Copyright (c) 2018 e-Sixt
+// Licensed under MIT
 //
+// See LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
 
 import Foundation
 

--- a/Sources/Swoctokit/Models/Repository.swift
+++ b/Sources/Swoctokit/Models/Repository.swift
@@ -14,9 +14,9 @@ import Foundation
 public struct Repository: Decodable {
 
     public let id: Int
-    public let nodeId: String
+    public let nodeId: String?
     public let name: String
-    public let fullName: String
-    public let owner: Owner
+    public let fullName: String?
+    public let owner: Owner?
 
 }

--- a/Sources/Swoctokit/Models/Repository.swift
+++ b/Sources/Swoctokit/Models/Repository.swift
@@ -15,11 +15,4 @@ public struct Repository: Decodable {
     public let fullName: String
     public let owner: Owner
 
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case nodeId = "node_id"
-        case name
-        case fullName = "full_name"
-        case owner
-    }
 }

--- a/Sources/Swoctokit/Repository/Branches/RepositoryBranchesBranchProtectionService.swift
+++ b/Sources/Swoctokit/Repository/Branches/RepositoryBranchesBranchProtectionService.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swoctokit open source project
+//
+// Copyright (c) 2018 e-Sixt
+// Licensed under MIT
+//
+// See LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Vapor
+
+public class RepositoryBranchesBranchService {
+
+    private let token: String
+    private let client: Client
+
+    init(token: String, client: Client) {
+        self.token = token
+        self.client = client
+    }
+
+    public func getBranch(owner: String, repository: String, branch: String) -> Future<Branch> {
+        let url = "\(Constants.GitHubBaseURL)/repos/\(owner)/\(repository)/branches/\(branch)"
+        let headers = HTTPHeaders([
+            ("Authorization", "token \(token)")
+        ])
+        return client.get(url, headers: headers).flatMap { response in
+            if let error = try? response.content.syncDecode(GitHubAPIErrorResponse.self) {
+                throw error
+            }
+
+            return try response.content.decode(json: Branch.self, using: .convertFromSnakeCase)
+        }
+    }
+
+}
+

--- a/Sources/Swoctokit/Repository/Commits/RepositoryCommitsCheckRunsService.swift
+++ b/Sources/Swoctokit/Repository/Commits/RepositoryCommitsCheckRunsService.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swoctokit open source project
+//
+// Copyright (c) 2018 e-Sixt
+// Licensed under MIT
+//
+// See LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Vapor
+
+public class RepositoryCommitsCheckRunsService {
+
+    private let token: String
+    private let client: Client
+
+    init(token: String, client: Client) {
+        self.token = token
+        self.client = client
+    }
+
+    public func getCheckRuns(owner: String, repository: String, ref: String) -> Future<[CheckRun]> {
+        let url = "\(Constants.GitHubBaseURL)/repos/\(owner)/\(repository)/commits/\(ref)/check-runs"
+        let headers = HTTPHeaders([
+            ("Authorization", "token \(token)"),
+            ("Accept", "application/vnd.github.antiope-preview+json")
+        ])
+        return client.get(url, headers: headers).flatMap { response in
+            if let error = try? response.content.syncDecode(GitHubAPIErrorResponse.self) {
+                throw error
+            }
+
+            return try response.content
+                .decode(json: CheckRunsResponse.self, using: .convertFromSnakeCase)
+                .map { $0.checkRuns }
+        }
+    }
+
+}
+
+struct CheckRunsResponse: Decodable {
+    let totalCount: Int
+    let checkRuns: [CheckRun]
+}

--- a/Sources/Swoctokit/Repository/Contents/Contents.swift
+++ b/Sources/Swoctokit/Repository/Contents/Contents.swift
@@ -1,9 +1,13 @@
+//===----------------------------------------------------------------------===//
 //
-//  Contents.swift
-//  Swoctokit
+// This source file is part of the Swoctokit open source project
 //
-//  Created by franz busch on 09.09.18.
+// Copyright (c) 2018 e-Sixt
+// Licensed under MIT
 //
+// See LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
 
 import Foundation
 

--- a/Sources/Swoctokit/Repository/Contents/RepositoryContentsService.swift
+++ b/Sources/Swoctokit/Repository/Contents/RepositoryContentsService.swift
@@ -32,7 +32,7 @@ public class RepositoryContentsService {
                 throw error
             }
 
-            return try response.content.decode(Contents.self)
+            return try response.content.decode(json: Contents.self, using: .convertFromSnakeCase)
         }
     }
 

--- a/Sources/Swoctokit/Repository/Contents/RepositoryFileUpdateRequest.swift
+++ b/Sources/Swoctokit/Repository/Contents/RepositoryFileUpdateRequest.swift
@@ -1,9 +1,13 @@
+//===----------------------------------------------------------------------===//
 //
-//  RepositoryFileUpdateRequest.swift
-//  Swoctokit
+// This source file is part of the Swoctokit open source project
 //
-//  Created by franz busch on 09.09.18.
+// Copyright (c) 2018 e-Sixt
+// Licensed under MIT
 //
+// See LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
 
 import Foundation
 

--- a/Sources/Swoctokit/Repository/PullRequests/RepositoryPullRequestService.swift
+++ b/Sources/Swoctokit/Repository/PullRequests/RepositoryPullRequestService.swift
@@ -29,7 +29,7 @@ public class RepositoryPullRequestService {
                 throw error
             }
 
-            return try response.content.decode(PullRequest.self)
+            return try response.content.decode(json: PullRequest.self, using: .convertFromSnakeCase)
         }
     }
 

--- a/Sources/Swoctokit/Repository/PullRequests/RepositoryPullRequestService.swift
+++ b/Sources/Swoctokit/Repository/PullRequests/RepositoryPullRequestService.swift
@@ -33,4 +33,27 @@ public class RepositoryPullRequestService {
         }
     }
 
+    public func mergePullRequest(owner: String, repository: String, number: Int) -> Future<Bool> {
+        let url = "\(Constants.GitHubBaseURL)/repos/\(owner)/\(repository)/pulls/\(number)/merge"
+
+        return client.put(url, headers: HTTPHeaders([("Authorization", "token \(token)")])).flatMap { response in
+            guard 200...300 ~= response.http.status.code else {
+                if let error = try? response.content.syncDecode(GitHubAPIErrorResponse.self) {
+                    throw error
+                }
+                throw Abort(.internalServerError, reason: "Merging the PR failed with: \(response.http.status.code)")
+            }
+
+            return try response.content
+                .decode(json: MergePullRequestResponse.self, using: .convertFromSnakeCase)
+                .map { $0.merged }
+        }
+    }
+
+}
+
+struct MergePullRequestResponse: Decodable {
+    let sha: String
+    let merged: Bool
+    let message: String
 }

--- a/Sources/Swoctokit/Swoctokit.swift
+++ b/Sources/Swoctokit/Swoctokit.swift
@@ -21,6 +21,7 @@ public class Swoctokit {
     public let contents: RepositoryContentsService
     public let pullRequests: RepositoryPullRequestService
     public let checkRuns: RepositoryCommitsCheckRunsService
+    public let branches: RepositoryBranchesBranchService
     public let teams: TeamsService
 
     public init(token: String, application: Application) throws {
@@ -31,6 +32,7 @@ public class Swoctokit {
         self.contents = RepositoryContentsService(token: token, client: client)
         self.pullRequests = RepositoryPullRequestService(token: token, client: client)
         self.checkRuns = RepositoryCommitsCheckRunsService(token: token, client: client)
+        self.branches = RepositoryBranchesBranchService(token: token, client: client)
     }
 
 }

--- a/Sources/Swoctokit/Swoctokit.swift
+++ b/Sources/Swoctokit/Swoctokit.swift
@@ -20,6 +20,7 @@ public class Swoctokit {
     public let repository: RepositoryService
     public let contents: RepositoryContentsService
     public let pullRequests: RepositoryPullRequestService
+    public let checkRuns: RepositoryCommitsCheckRunsService
     public let teams: TeamsService
 
     public init(token: String, application: Application) throws {
@@ -29,6 +30,7 @@ public class Swoctokit {
         self.teams = TeamsService(token: token, client: client)
         self.contents = RepositoryContentsService(token: token, client: client)
         self.pullRequests = RepositoryPullRequestService(token: token, client: client)
+        self.checkRuns = RepositoryCommitsCheckRunsService(token: token, client: client)
     }
 
 }

--- a/Sources/Swoctokit/SwoctokitWebhookClient.swift
+++ b/Sources/Swoctokit/SwoctokitWebhookClient.swift
@@ -29,6 +29,13 @@ public protocol IssueCommentEventListener: AnyObject {
 
 }
 
+
+public protocol CheckRunEventListener: AnyObject {
+
+    func checkRunEventReceived(_ event: CheckRunEvent)
+
+}
+
 public class SwoctokitWebhookClient {
 
     private let application: Application
@@ -36,6 +43,7 @@ public class SwoctokitWebhookClient {
     private var pullRequestEventListeners = [PullRequestEventListener]()
     private var commitCommentEventListeners = [CommitCommentEventListener]()
     private var issueCommentEventListeners = [IssueCommentEventListener]()
+    private var checkRunEventListeners = [CheckRunEventListener]()
 
     public init(_ application: Application) throws {
         self.application = application
@@ -62,6 +70,10 @@ public class SwoctokitWebhookClient {
         issueCommentEventListeners.append(listener)
     }
 
+    public func addCheckRunEventListener(_ listener: CheckRunEventListener) {
+        checkRunEventListeners.append(listener)
+    }
+
 }
 
 extension SwoctokitWebhookClient: WebhookControllerDelegate {
@@ -73,7 +85,9 @@ extension SwoctokitWebhookClient: WebhookControllerDelegate {
         case let event as CommitCommentEvent:
             commitCommentEventReceived(event)
         case let event as IssueCommentEvent:
-            isuueCommentEventReceived(event)
+            issueCommentEventReceived(event)
+        case let event as CheckRunEvent:
+            checkRunEventReceived(event)
         default:
             break
         }
@@ -87,8 +101,12 @@ extension SwoctokitWebhookClient: WebhookControllerDelegate {
         commitCommentEventListeners.forEach { $0.commitCommentEventReceived(event) }
     }
 
-    func isuueCommentEventReceived(_ event: IssueCommentEvent) {
+    func issueCommentEventReceived(_ event: IssueCommentEvent) {
         issueCommentEventListeners.forEach { $0.issueCommentEventReceived(event) }
+    }
+
+    func checkRunEventReceived(_ event: CheckRunEvent) {
+        checkRunEventListeners.forEach { $0.checkRunEventReceived(event) }
     }
 
 }

--- a/Sources/Swoctokit/Webhook/CheckRunEvent.swift
+++ b/Sources/Swoctokit/Webhook/CheckRunEvent.swift
@@ -9,11 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
+public struct CheckRunEvent: Decodable, WebhookEvent {
 
-public enum EventType: String {
-    case pullRequest = "pull_request"
-    case commitComment = "commit_comment"
-    case issueComment = "issue_comment"
-    case checkRun = "check_run"
+    public let action: String
+    public let checkRun: CheckRun
+
 }

--- a/Sources/Swoctokit/Webhook/CheckRunEvent.swift
+++ b/Sources/Swoctokit/Webhook/CheckRunEvent.swift
@@ -13,5 +13,6 @@ public struct CheckRunEvent: Decodable, WebhookEvent {
 
     public let action: String
     public let checkRun: CheckRun
+    public let repository: Repository
 
 }

--- a/Sources/Swoctokit/Webhook/CommitCommentEvent.swift
+++ b/Sources/Swoctokit/Webhook/CommitCommentEvent.swift
@@ -19,11 +19,4 @@ public struct CommitComment: Decodable {
     public let body: String
     public let commitId: String
 
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case url
-        case body
-        case commitId = "commit_id"
-    }
-
 }

--- a/Sources/Swoctokit/Webhook/CommitCommentEvent.swift
+++ b/Sources/Swoctokit/Webhook/CommitCommentEvent.swift
@@ -1,9 +1,13 @@
+//===----------------------------------------------------------------------===//
 //
-//  CommitCommentEvent.swift
-//  Swoctokit
+// This source file is part of the Swoctokit open source project
 //
-//  Created by Franz Busch on 14.11.18.
+// Copyright (c) 2018 e-Sixt
+// Licensed under MIT
 //
+// See LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
 
 public struct CommitCommentEvent: Decodable, WebhookEvent {
 

--- a/Sources/Swoctokit/Webhook/IssueCommentEvent.swift
+++ b/Sources/Swoctokit/Webhook/IssueCommentEvent.swift
@@ -1,9 +1,13 @@
+//===----------------------------------------------------------------------===//
 //
-//  IssueCommentEvent.swift
-//  Swoctokit
+// This source file is part of the Swoctokit open source project
 //
-//  Created by Franz Busch on 14.11.18.
+// Copyright (c) 2018 e-Sixt
+// Licensed under MIT
 //
+// See LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
 
 import Foundation
 

--- a/Sources/Swoctokit/Webhook/PullRequestEvent.swift
+++ b/Sources/Swoctokit/Webhook/PullRequestEvent.swift
@@ -1,9 +1,13 @@
+//===----------------------------------------------------------------------===//
 //
-//  File.swift
-//  Swoctokit
+// This source file is part of the Swoctokit open source project
 //
-//  Created by franz busch on 13.09.18.
+// Copyright (c) 2018 e-Sixt
+// Licensed under MIT
 //
+// See LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
 
 public struct PullRequestEvent: Decodable, WebhookEvent {
 

--- a/Sources/Swoctokit/Webhook/PullRequestEvent.swift
+++ b/Sources/Swoctokit/Webhook/PullRequestEvent.swift
@@ -11,12 +11,6 @@ public struct PullRequestEvent: Decodable, WebhookEvent {
     public let number: Int
     public let pullRequest: PullRequest
 
-    private enum CodingKeys: String, CodingKey {
-        case action
-        case number
-        case pullRequest = "pull_request"
-    }
-
 }
 
 

--- a/Sources/Swoctokit/Webhook/WebhookController.swift
+++ b/Sources/Swoctokit/Webhook/WebhookController.swift
@@ -43,16 +43,24 @@ final class WebhookController: RouteCollection {
 
         switch eventType {
         case .pullRequest:
-            if let pullRequestEvent = try? req.content.syncDecode(PullRequestEvent.self) {
+            if let future = try? req.content.decode(json: PullRequestEvent.self, using: .convertFromSnakeCase) {
+                let pullRequestEvent = try future.wait()
                 delegate?.didReceive(event: pullRequestEvent)
             }
         case .commitComment:
-            if let commitCommentEvent = try? req.content.syncDecode(CommitCommentEvent.self) {
+            if let future = try? req.content.decode(json: CommitCommentEvent.self, using: .convertFromSnakeCase) {
+                let commitCommentEvent = try future.wait()
                 delegate?.didReceive(event: commitCommentEvent)
             }
         case .issueComment:
-            if let issueCommentEvent = try? req.content.syncDecode(IssueCommentEvent.self) {
+            if let future = try? req.content.decode(json: IssueCommentEvent.self, using: .convertFromSnakeCase) {
+                let issueCommentEvent = try future.wait()
                 delegate?.didReceive(event: issueCommentEvent)
+            }
+        case .checkRun:
+            if let future = try? req.content.decode(json: CheckRunEvent.self, using: .convertFromSnakeCase) {
+                let checkRunEvent = try future.wait()
+                delegate?.didReceive(event: checkRunEvent)
             }
         }
 


### PR DESCRIPTION
# Description
This PR adds support for the `check_runs` webhook event as described in [GitHub's API Documentation](https://developer.github.com/v3/activity/events/types/#checkrunevent).

To do so, I had to make a few of the existing properties optional, as they are not always returned.

Additionally, I added a static JSONDecoder that uses the `.convertFromSnakeCase` key decoding strategy. This allowed to remove some custom `CodingKeys` enums.