### PR TITLE
Add support to listen for pull_request_review webhooks

### DIFF
--- a/Sources/Swoctokit/Models/Branch.swift
+++ b/Sources/Swoctokit/Models/Branch.swift
@@ -28,6 +28,7 @@ extension Branch {
     public struct Protection: Decodable {
         public let enabled: Bool
         public let requiredStatusChecks: RequiredStatusChecks
+        public let requiredPullRequestReviews: RequiredPullRequestReviews?
     }
 }
 
@@ -35,5 +36,9 @@ extension Branch.Protection {
     public struct RequiredStatusChecks: Decodable {
         public let enforcementLevel: String
         public let contexts: [String]
+    }
+
+    public struct RequiredPullRequestReviews: Decodable {
+        public let requiredApprovingReviewCount: Int
     }
 }

--- a/Sources/Swoctokit/Models/Review.swift
+++ b/Sources/Swoctokit/Models/Review.swift
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swoctokit open source project
+//
+// Copyright (c) 2018 e-Sixt
+// Licensed under MIT
+//
+// See LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+public struct Review: Decodable {
+    public let id: Int
+    public let commitId: String
+    public let state: String
+}

--- a/Sources/Swoctokit/Models/User.swift
+++ b/Sources/Swoctokit/Models/User.swift
@@ -11,9 +11,7 @@
 
 import Foundation
 
-public struct Review: Decodable {
+public struct User: Decodable, Equatable, Hashable {
     public let id: Int
-    public let user: User
-    public let commitId: String
-    public let state: String
+    public let login: String // Username
 }

--- a/Sources/Swoctokit/Repository/PullRequests/RepositoryPullRequestService.swift
+++ b/Sources/Swoctokit/Repository/PullRequests/RepositoryPullRequestService.swift
@@ -50,6 +50,18 @@ public class RepositoryPullRequestService {
         }
     }
 
+    public func getReviews(owner: String, repository: String, number: Int) -> Future<[Review]> {
+        let url = "\(Constants.GitHubBaseURL)/repos/\(owner)/\(repository)/pulls/\(number)/reviews"
+
+        return client.get(url, headers: HTTPHeaders([("Authorization", "token \(token)")])).flatMap { response in
+            if let error = try? response.content.syncDecode(GitHubAPIErrorResponse.self) {
+                throw error
+            }
+
+            return try response.content.decode(json: [Review].self, using: .convertFromSnakeCase)
+        }
+    }
+
 }
 
 struct MergePullRequestResponse: Decodable {

--- a/Sources/Swoctokit/SwoctokitWebhookClient.swift
+++ b/Sources/Swoctokit/SwoctokitWebhookClient.swift
@@ -36,6 +36,12 @@ public protocol CheckRunEventListener: AnyObject {
 
 }
 
+public protocol PullRequestReviewEventListener: AnyObject {
+
+    func pullRequestReviewEventReceived(_ event: PullRequestReviewEvent)
+
+}
+
 public class SwoctokitWebhookClient {
 
     private let application: Application
@@ -44,6 +50,7 @@ public class SwoctokitWebhookClient {
     private var commitCommentEventListeners = [CommitCommentEventListener]()
     private var issueCommentEventListeners = [IssueCommentEventListener]()
     private var checkRunEventListeners = [CheckRunEventListener]()
+    private var pullRequestReviewEventListeners = [PullRequestReviewEventListener]()
 
     public init(_ application: Application) throws {
         self.application = application
@@ -74,6 +81,10 @@ public class SwoctokitWebhookClient {
         checkRunEventListeners.append(listener)
     }
 
+    public func addPullRequestReviewEventListener(_ listener: PullRequestReviewEventListener) {
+        pullRequestReviewEventListeners.append(listener)
+    }
+
 }
 
 extension SwoctokitWebhookClient: WebhookControllerDelegate {
@@ -88,6 +99,8 @@ extension SwoctokitWebhookClient: WebhookControllerDelegate {
             issueCommentEventReceived(event)
         case let event as CheckRunEvent:
             checkRunEventReceived(event)
+        case let event as PullRequestReviewEvent:
+            pullRequestReviewEventReceived(event)
         default:
             break
         }
@@ -107,6 +120,10 @@ extension SwoctokitWebhookClient: WebhookControllerDelegate {
 
     func checkRunEventReceived(_ event: CheckRunEvent) {
         checkRunEventListeners.forEach { $0.checkRunEventReceived(event) }
+    }
+
+    func pullRequestReviewEventReceived(_ event: PullRequestReviewEvent) {
+        pullRequestReviewEventListeners.forEach { $0.pullRequestReviewEventReceived(event) }
     }
 
 }

--- a/Sources/Swoctokit/Webhook/PullRequestEvent.swift
+++ b/Sources/Swoctokit/Webhook/PullRequestEvent.swift
@@ -14,6 +14,7 @@ public struct PullRequestEvent: Decodable, WebhookEvent {
     public let action: String
     public let number: Int
     public let pullRequest: PullRequest
+    public let repository: Repository
 
 }
 

--- a/Sources/Swoctokit/Webhook/PullRequestReviewEvent.swift
+++ b/Sources/Swoctokit/Webhook/PullRequestReviewEvent.swift
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swoctokit open source project
+//
+// Copyright (c) 2018 e-Sixt
+// Licensed under MIT
+//
+// See LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+public struct PullRequestReviewEvent: Decodable, WebhookEvent {
+
+    public let action: String
+    public let pullRequest: PullRequest
+    public let repository: Repository
+
+}


### PR DESCRIPTION
# Description
This PR adds support for the `pull_request_review ` webhook event as described in [GitHub's API Documentation](https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent).

Additionally, I added a `getReviews` method to get all reviews of a particular pull request.